### PR TITLE
Fix typos in project name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# AWS Indentity Sight
+# AWS Identity Sight
 
 This tools is designed to generate an HTML report of IAM Identity Center.
 

--- a/script/sso_account_assignments_html_report.py
+++ b/script/sso_account_assignments_html_report.py
@@ -226,7 +226,7 @@ def main():
     """
     Main function to generate the SSO report.
     """
-    print("🗼 AWS Indentity Sight 🗼\n\n")
+    print("🗼 AWS Identity Sight 🗼\n\n")
     print("ℹ️  Generating AWS Identity Center Assignment Report...\n")
     start_time = time.time()
     account_list = list_active_accounts()


### PR DESCRIPTION
## Summary
- correct heading in README
- fix spelling of project name in startup message

## Testing
- `python3 -m py_compile script/sso_account_assignments_html_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68400ca343b083309c9c60b354bbce62