### PR TITLE
Fix error handling for SSO instance lookup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# AWS Indentity Sight
+# AWS Identity Sight
 
 This tools is designed to generate an HTML report of IAM Identity Center.
 

--- a/script/sso_account_assignments_html_report.py
+++ b/script/sso_account_assignments_html_report.py
@@ -44,8 +44,14 @@ def get_sso_instance_name(sso_instance_arn):
         else:
             return response['IdentityStoreId']
     except Exception as e:
-        logging.exception("An error occurred while retrieving the name of the AWS SSO instance: %s", str(e))
-        return response['OwnerAccountId']
+        logging.exception(
+            "An error occurred while retrieving the name of the AWS SSO instance: %s",
+            str(e),
+        )
+        # In error cases we can't rely on the describe_instance response.  Returning
+        # ``None`` prevents referencing an undefined variable and signals the caller
+        # that the name could not be determined.
+        return None
 
 def list_permission_sets(sso_instance_arn):
     """
@@ -226,7 +232,8 @@ def main():
     """
     Main function to generate the SSO report.
     """
-    print("🗼 AWS Indentity Sight 🗼\n\n")
+    # Friendly banner for the start of the report generation
+    print("🗼 AWS Identity Sight 🗼\n\n")
     print("ℹ️  Generating AWS Identity Center Assignment Report...\n")
     start_time = time.time()
     account_list = list_active_accounts()


### PR DESCRIPTION
## Summary
- handle exceptions when fetching SSO instance name
- show correct banner title when running the report

## Testing
- `python -m py_compile script/sso_account_assignments_html_report.py`

------
https://chatgpt.com/codex/tasks/task_e_68400c1aef688330aa67bd475a79c33f